### PR TITLE
Fixed Background image bug

### DIFF
--- a/repository-block.css
+++ b/repository-block.css
@@ -10,6 +10,7 @@
 	box-shadow: 10px 10px 15px 0px rgba(0,0,0,0.75);
 	border-radius: .5em;
 	border: 1px solid #eee;
+	z-index: -1;
 }
 
 .ebg-br-wrapper-dark-mode-on {


### PR DESCRIPTION
The background image was covering the whole block preventing any of the links from being clicked. Hard setting the z-index to -1 ensures that it will not overlay the block content.