### PR TITLE
Fix for image overlaying links

### DIFF
--- a/repository-block.css
+++ b/repository-block.css
@@ -22,6 +22,7 @@
 	background-position: calc(100% - 0.5em) 0.5em;
 	background-size: 20px 20px;
 	position: absolute;
+	z-index: -1;
     left: 0;
     top: 0;
     width: 100%;


### PR DESCRIPTION
The background image is being automatically placed on the same z-index as the content and it is loading before the content, so it is covering it with an invisible image making it so that the links cannot be clicked. Forcing the background image to z-index -1 fixes this issue.